### PR TITLE
add missing params var for discount / addToCharge

### DIFF
--- a/resources/discount.js
+++ b/resources/discount.js
@@ -19,7 +19,7 @@ Discount.prototype.addToAddress = function addToAddress(address_id, params) {
     return this.recharge.request(url, 'POST', 'address', params);
 };
 
-Discount.prototype.addToCharge = function addToCharge(charge_id) {
+Discount.prototype.addToCharge = function addToCharge(charge_id, params) {
     const path = `/charges/${charge_id}/apply_discount`;
     const url = assign({ path }, this.recharge.baseUrl);
     return this.recharge.request(url, 'POST', 'charge', params);


### PR DESCRIPTION
Parameters are required in order to add a discount to a charge. The `params` parameter is used but never defined in `addToCharge`.